### PR TITLE
Add boards, domains, and lineages

### DIFF
--- a/screens/Boards.js
+++ b/screens/Boards.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { View, Text, StyleSheet, FlatList } from 'react-native';
+import Item from '../components/Item';
+
+const BOARDS = [
+  { name: 'London ~ Whitechapel', key: 'london-whitechapel' },
+  { name: 'London ~ Southwark', key: 'london-southwark' },
+  { name: 'London ~ Old London', key: 'london-old-london' },
+  { name: 'Underground ~ Hive', key: 'underground-hive' },
+  { name: 'Luxor ~ Karnak Temple', key: 'luxor-karnak-temple' },
+  { name: 'Cairo ~ Old City', key: 'cairo-old-city' },
+  { name: 'Giza ~ Necropolis', key: 'giza-necropolis' },
+];
+
+const Boards = () => {
+  return (
+    <View style={styles.container}>
+      <Text>Boards to include</Text>
+      <FlatList
+        data={BOARDS}
+        keyExtractor={(item) => item.key}
+        renderItem={({ item, index }) => {
+          return <Item name={item.name} />;
+        }}
+      />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#000',
+  },
+});
+
+export default Boards;

--- a/screens/Domains.js
+++ b/screens/Domains.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import { View, Text, StyleSheet, FlatList } from 'react-native';
+import Item from '../components/Item';
+
+const DOMAINS = [
+  { name: 'Haunted Forest', key: 'haunted-forest' },
+  { name: 'Forgotten Temple', key: 'forgotten-temple' },
+  { name: 'Outcast Sanctuary', key: 'outcast-sanctuary' },
+  { name: 'Screaming Coast', key: 'screaming-coast' },
+  { name: 'Bloodsoaked Fjord', key: 'bloodsoaked-fjord' },
+  { name: 'Forsaken Church', key: 'forsaken-church' },
+  { name: 'Lunatic Asylum', key: 'lunatic-asylum' },
+  { name: 'Royal Palace', key: 'royal-palace' },
+  { name: 'Witch Mountain', key: 'witch-mountain' },
+  { name: 'Bewitched Woodland', key: 'bewitched-woodland' },
+  { name: 'Bloodcursed Ship', key: 'bloodcursed-ship' },
+  { name: 'Forlorn Opera House', key: 'forlorn-opera-house' },
+];
+
+const Domains = () => {
+  return (
+    <View style={styles.container}>
+      <Text>Domains to include</Text>
+      <FlatList
+        data={DOMAINS}
+        keyExtractor={(item) => item.key}
+        renderItem={({ item, index }) => {
+          return <Item name={item.name} />;
+        }}
+      />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#000',
+  },
+});
+
+export default Domains;

--- a/screens/Lineages.js
+++ b/screens/Lineages.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { View, Text, StyleSheet, FlatList } from 'react-native';
+import Item from '../components/Item';
+
+const LINEAGES = [
+  { name: 'Animist', key: 'animist' },
+  { name: 'Demonologist', key: 'demonologist' },
+  { name: 'Bloodlord', key: 'bloodlord' },
+  { name: 'Necromancer', key: 'necromancer' },
+  { name: 'Druid', key: 'druid' },
+  { name: 'House of Petro', key: 'petro' },
+  { name: 'Children of Alyisia', key: 'alyisia' },
+  { name: 'Sword of Gabriel', key: 'gabriel' },
+];
+
+const Lineages = () => {
+  return (
+    <View style={styles.container}>
+      <Text>Lineages to include</Text>
+      <FlatList
+        data={LINEAGES}
+        keyExtractor={(item) => item.key}
+        renderItem={({ item, index }) => {
+          return <Item name={item.name} />;
+        }}
+      />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#000',
+  },
+});
+
+export default Lineages;


### PR DESCRIPTION
Added screens for boards, domains, and lineages.  Currently there is nothing navigating to these screens.  The code is similar to that for characters, but with specific keys included for the keyExtractor.  I may end up also updating characters to include a preset key for consistency sake, but currently focusing on functionality.